### PR TITLE
Fix comparison of existing status with value

### DIFF
--- a/src/com/android/bluetooth/bthelper/utils/AACPManager.kt
+++ b/src/com/android/bluetooth/bthelper/utils/AACPManager.kt
@@ -55,7 +55,7 @@ object AACPManager {
         value: ByteArray,
     ) {
         val existingStatus = getControlCommandStatus(identifier)
-        if (existingStatus == value) {
+        if (existingStatus?.value?.contentEquals(value) == true) {
             controlCommandStatusList.remove(existingStatus)
         }
         if (existingStatus != null) {


### PR DESCRIPTION
FAILED: out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlin/BtHelper.jar out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlin_headers/BtHelper.jar rm -rf "out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlinc/classes" "out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlinc/header_classes" "out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlinc/srcJars" "out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlinc-build.xml" "out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlinc/empty" && mkdir -p "out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlinc/classes" "out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlinc/header_classes" "out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlinc/srcJars" "out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlinc/empty" && out/host/linux-x86/bin/zipsync -d out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlinc/srcJars -l out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlinc/srcJars/list -f "*.java" -f "*.kt" && out/host/linux-x86/bin/gen-kotlin-build-file --classpath "out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlinc/classpath.rsp" --name "packages__apps__BtHelper__android_common__BtHelper" --out_dir "out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlinc/classes" --srcs "out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlin/BtHelper.jar.rsp" --srcs "out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlinc/srcJars/list" --out "out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlinc-build.xml" && external/kotlinc/bin/kotlinc -J--add-opens=java.base/java.util=ALL-UNNAMED -J-Xmx4096M -Xsam-conversions=class -no-stdlib -no-jdk -jvm-target 17 -Xbuild-file=out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlinc-build.xml -kotlin-home out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlinc/empty -Xplugin=external/kotlinc/lib/jvm-abi-gen.jar -P plugin:org.jetbrains.kotlin.jvm.abi:outputDir=out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlinc/header_classes && out/host/linux-x86/bin/soong_zip -jar -o out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlin/BtHelper.jar -C out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlinc/classes -D out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlinc/classes -write_if_changed && out/host/linux-x86/bin/soong_zip -jar -o out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlin_headers/BtHelper.jar -C out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlinc/header_classes -D out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlinc/header_classes -write_if_changed && rm -rf "out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlinc/srcJars" "out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlinc/classes" "out/soong/.intermediates/packages/apps/BtHelper/BtHelper/android_common/kotlinc/header_classes" packages/apps/BtHelper/src/com/android/bluetooth/bthelper/utils/AACPManager.kt:58:13: error: operator '==' cannot be applied to 'AACPManager.ControlCommandStatus?' and 'ByteArray' if (existingStatus == value) {